### PR TITLE
docs: describe the default value of `trace_by_commit_hash_when_pr_not_found` explicitly in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Then, you can use the following commands.
 require('trace-pr').setup({
   -- Whether to trace on commit if Pull Request is not found, e.g. if it is committed directly.
   -- If false, the tracking is terminated with an warning message.
-  -- Default: false
+  -- Default: true
   trace_by_commit_hash_when_pr_not_found = true,
 })
 ```

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Then, you can use the following commands.
 require('trace-pr').setup({
   -- Whether to trace on commit if Pull Request is not found, e.g. if it is committed directly.
   -- If false, the tracking is terminated with an warning message.
+  -- Default: false
   trace_by_commit_hash_when_pr_not_found = true,
 })
 ```


### PR DESCRIPTION
Thanks for developing very useful neovim plugin!

I think that it would be easier to determine whether configuration changes are necessary if the default value was clearly documented.