### PR TITLE
fix: merge commit の場合、PR ではなくコミットに飛んでしまう問題を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ The plugin consists of several modules under `lua/trace-pr/`:
 ## Development Commands
 
 - **Linting**: `stylua .` (configured in stylua.toml with 2-space indentation)
-- **Testing**: No test framework detected in codebase
+- **Testing**: `make test` (requires plenary.nvim and `jq` in PATH)
 
 ## Dependencies
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: test test-file format help
+
+test:
+	nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests/unit/ {minimal_init = 'tests/minimal_init.lua'}"
+
+test-file:
+	nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile $(FILE)"
+
+format:
+	stylua .
+
+help:
+	@echo "Available targets:"
+	@echo "  test        - Run all tests"
+	@echo "  test-file   - Run specific test file (usage: make test-file FILE=tests/unit/pr_number_spec.lua)"
+	@echo "  format      - Format code with stylua"
+	@echo "  help        - Show this help"

--- a/lua/trace-pr/pr_number.lua
+++ b/lua/trace-pr/pr_number.lua
@@ -14,9 +14,13 @@ local function build_gh_pr_command(commit_hash)
       "-S",
       commit_hash,
       "--json",
-      "number,mergeCommit",
+      "number,mergeCommit,commits",
       "--jq",
-      ".[] | select(.mergeCommit.oid == \"" .. commit_hash .. "\") | .number",
+      ".[] | select(.mergeCommit.oid == \""
+        .. commit_hash
+        .. "\" or any(.commits[]; .oid == \""
+        .. commit_hash
+        .. "\")) | .number",
     },
     env = {
       NO_COLOR = "1",
@@ -32,8 +36,8 @@ function M.get(commit_hash)
   local gh_pr_command = build_gh_pr_command(commit_hash)
   local gh_pr_result = vim.system(gh_pr_command.cmd, { env = gh_pr_command.env, text = true }):wait()
 
-  -- Remove the trailing newline code
-  local pr_number = gh_pr_result.stdout:gsub("[\n]", "")
+  -- Take the first line only (multiple PRs may match in rare cases) and strip newline
+  local pr_number = gh_pr_result.stdout:match("[^\n]+") or ""
 
   return tonumber(pr_number)
 end

--- a/lua/trace-pr/pr_number.lua
+++ b/lua/trace-pr/pr_number.lua
@@ -42,4 +42,7 @@ function M.get(commit_hash)
   return tonumber(pr_number)
 end
 
+-- Exposed for testing
+M._build_gh_pr_command = build_gh_pr_command
+
 return M

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -1,0 +1,68 @@
+local M = {}
+
+local HASH = "abc1234567890abcdef1234567890abcdef123456"
+local OTHER = "deadbeef1234567890abcdef1234567890deadbeef"
+
+M.HASH = HASH
+M.OTHER = OTHER
+
+--- Build a mock for vim.system that returns canned stdout.
+---@param stdout string
+---@return function
+function M.stub_vim_system(stdout)
+  return function()
+    return {
+      wait = function()
+        return { stdout = stdout, code = 0 }
+      end,
+    }
+  end
+end
+
+--- Fixture: squash merge (blamed commit IS the merge commit).
+function M.fixture_squash()
+  return string.format([=[[{"number": 1, "mergeCommit": {"oid": "%s"}, "commits": [{"oid": "%s"}]}]]=], HASH, HASH)
+end
+
+--- Fixture: rebase merge (blamed commit is one of .commits[], NOT the mergeCommit).
+function M.fixture_rebase()
+  return string.format(
+    [=[[{"number": 2, "mergeCommit": {"oid": "%s"}, "commits": [{"oid": "%s"}, {"oid": "%s"}]}]]=],
+    OTHER,
+    "1111111111111111111111111111111111111111",
+    HASH
+  )
+end
+
+--- Fixture: merge commit --no-ff (blamed commit lives inside .commits[]).
+function M.fixture_merge_commit()
+  return string.format([=[[{"number": 3, "mergeCommit": {"oid": "%s"}, "commits": [{"oid": "%s"}]}]]=], OTHER, HASH)
+end
+
+--- Fixture: hash mentioned only in PR body (false positive guard).
+function M.fixture_body_only()
+  return string.format([=[[{"number": 4, "mergeCommit": {"oid": "%s"}, "commits": [{"oid": "%s"}]}]]=], OTHER, OTHER)
+end
+
+--- Fixture: empty search result.
+function M.fixture_empty()
+  return "[]"
+end
+
+--- Run jq filter against JSON fixture via io.popen.
+---@param filter string jq filter expression
+---@param json string JSON input
+---@return string trimmed stdout
+function M.run_jq(filter, json)
+  local tmp = os.tmpname()
+  local f = assert(io.open(tmp, "w"))
+  f:write(json)
+  f:close()
+  local handle = assert(io.popen("jq -r '" .. filter .. "' " .. tmp .. " 2>&1"))
+  local out = handle:read("*a")
+  handle:close()
+  os.remove(tmp)
+  return (out:gsub("%s+$", ""))
+end
+
+return M

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,0 +1,5 @@
+vim.cmd([[set runtimepath+=.]])
+vim.cmd([[set runtimepath+=~/.local/share/nvim/lazy/plenary.nvim]])
+
+vim.o.swapfile = false
+vim.o.hidden = true

--- a/tests/unit/pr_number_spec.lua
+++ b/tests/unit/pr_number_spec.lua
@@ -1,0 +1,68 @@
+local helpers = require("tests.helpers")
+local pr_number = require("trace-pr.pr_number")
+
+describe("pr_number", function()
+  local original_vim_system
+
+  before_each(function()
+    original_vim_system = vim.system
+  end)
+
+  after_each(function()
+    vim.system = original_vim_system
+  end)
+
+  describe("jq filter", function()
+    local function get_jq_filter(hash)
+      local cmd = pr_number._build_gh_pr_command(hash).cmd
+      return cmd[#cmd]
+    end
+
+    it("should match squash merge (mergeCommit.oid == blamed hash)", function()
+      local filter = get_jq_filter(helpers.HASH)
+      local result = helpers.run_jq(filter, helpers.fixture_squash())
+      assert.are.equal("1", result)
+    end)
+
+    it("should match rebase merge (commits[].oid == blamed hash)", function()
+      local filter = get_jq_filter(helpers.HASH)
+      local result = helpers.run_jq(filter, helpers.fixture_rebase())
+      assert.are.equal("2", result)
+    end)
+
+    it("should match merge commit (commits[].oid == blamed hash)", function()
+      local filter = get_jq_filter(helpers.HASH)
+      local result = helpers.run_jq(filter, helpers.fixture_merge_commit())
+      assert.are.equal("3", result)
+    end)
+
+    it("should not match when hash is only in PR body (false positive guard)", function()
+      local filter = get_jq_filter(helpers.HASH)
+      local result = helpers.run_jq(filter, helpers.fixture_body_only())
+      assert.are.equal("", result)
+    end)
+
+    it("should return empty for no search results", function()
+      local filter = get_jq_filter(helpers.HASH)
+      local result = helpers.run_jq(filter, helpers.fixture_empty())
+      assert.are.equal("", result)
+    end)
+  end)
+
+  describe("get", function()
+    it("should parse a single PR number", function()
+      vim.system = helpers.stub_vim_system("42\n")
+      assert.are.equal(42, pr_number.get(helpers.HASH))
+    end)
+
+    it("should return nil for empty stdout", function()
+      vim.system = helpers.stub_vim_system("")
+      assert.is_nil(pr_number.get(helpers.HASH))
+    end)
+
+    it("should return the first PR number when multiple match", function()
+      vim.system = helpers.stub_vim_system("7\n8\n")
+      assert.are.equal(7, pr_number.get(helpers.HASH))
+    end)
+  end)
+end)


### PR DESCRIPTION
## 概要

`:TracePR` を実行した際、PR の詳細ページに飛ぶことを期待しているのに、コミットの詳細ページに飛んでしまうケースがありました。

具体的には **create a merge commit** でマージされた PR の行では常にコミットへフォールバックしていました。**squash and merge** のみ正しく動作していました。

この PR で各種マージ方式すべてで正しく PR ページが開くようになります。

## 技術的な詳細

### 原因

PR 検出の jq フィルタが `mergeCommit.oid` との完全一致のみで判定していました。

- **squash merge**: blame のコミット = マージコミット → ✅ 一致
- **rebase merge**: blame のコミットは `.commits[]` 内の個別コミット → ❌ 不一致
- **merge commit**: blame のコミットは元ブランチのコミット → ❌ 不一致

### 修正内容

- jq フィルタに `.commits[].oid` との一致チェックを追加 (`any(.commits[]; .oid == <hash>)`)
- PR 本文にハッシュが偶然含まれるケースでの誤検出は引き続き防止
- 複数 PR がヒットした場合に `tonumber` が nil になる不具合もあわせて修正
- plenary.nvim によるテストを追加 (jq フィルタの各マージ方式・誤検出ガード・パース処理)

## Test plan
- [ ] squash merge された PR の行で `:TracePR` し、PR が開くこと
- [ ] rebase merge された PR の行で `:TracePR` し、PR が開くこと
- [ ] merge commit でマージされた PR の行で `:TracePR` し、PR が開くこと
- [ ] PR が存在しない行で、設定通りコミット詳細にフォールバックすること
- [ ] `make test` で全テストが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)